### PR TITLE
Speedup building docker images in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,13 +48,25 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+        # Build until the "build" stage, this then can be used by other steps.
+      - name: Build "build" image
+        if: github.ref_name == 'main'
+        id: docker_build_monolith
+        uses: docker/build-push-action@v3
+        with:
+          target: build
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache,mode=max
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+
       - name: Build main monolith image
         if: github.ref_name == 'main'
         id: docker_build_monolith
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-monolith:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-monolith:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           platforms: ${{ env.PLATFORMS }}
           push: true
@@ -67,8 +79,7 @@ jobs:
         id: docker_build_monolith_release
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           platforms: ${{ env.PLATFORMS }}
           push: true
@@ -124,8 +135,7 @@ jobs:
         id: docker_build_demo_pinecone
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           file: ./build/docker/Dockerfile.demo-pinecone
           platforms: ${{ env.PLATFORMS }}
@@ -139,8 +149,7 @@ jobs:
         id: docker_build_demo_pinecone_release
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           file: ./build/docker/Dockerfile.demo-pinecone
           platforms: ${{ env.PLATFORMS }}
@@ -185,8 +194,7 @@ jobs:
         id: docker_build_demo_yggdrasil
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           file: ./build/docker/Dockerfile.demo-yggdrasil
           platforms: ${{ env.PLATFORMS }}
@@ -200,8 +208,7 @@ jobs:
         id: docker_build_demo_yggdrasil_release
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite:buildcache
           context: .
           file: ./build/docker/Dockerfile.demo-yggdrasil
           platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
 
         # Build until the "build" stage, this then can be used by other steps.
       - name: Build "build" image
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'main' || github.event_name == 'release'
         id: docker_build_monolith
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -104,6 +104,7 @@ jobs:
   demo-pinecone:
     name: Pinecone demo image
     runs-on: ubuntu-latest
+    needs: monolith
     permissions:
       contents: read
       packages: write
@@ -163,6 +164,7 @@ jobs:
   demo-yggdrasil:
     name: Yggdrasil demo image
     runs-on: ubuntu-latest
+    needs: monolith
     permissions:
       contents: read
       packages: write

--- a/build/docker/Dockerfile.demo-pinecone
+++ b/build/docker/Dockerfile.demo-pinecone
@@ -1,29 +1,16 @@
-FROM docker.io/golang:1.22-alpine AS base
-
-#
-# Needs to be separate from the main Dockerfile for OpenShift,
-# as --target is not supported there.
-#
-
-RUN apk --update --no-cache add bash build-base
-
-WORKDIR /build
-
-COPY . /build
-
-RUN mkdir -p bin
-RUN go build -trimpath -o bin/ ./cmd/dendrite-demo-pinecone
-RUN go build -trimpath -o bin/ ./cmd/create-account
-RUN go build -trimpath -o bin/ ./cmd/generate-keys
+FROM --platform=${BUILDPLATFORM} ghcr.io/element-hq/dendrite:buildcache AS build
 
 FROM alpine:latest
 RUN apk --update --no-cache add curl
 LABEL org.opencontainers.image.title="Dendrite (Pinecone demo)"
 LABEL org.opencontainers.image.description="Next-generation Matrix homeserver written in Go"
 LABEL org.opencontainers.image.source="https://github.com/matrix-org/dendrite"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only OR LicenseRef-Element-Commercial"
 
-COPY --from=base /build/bin/* /usr/bin/
+COPY --from=build /out/create-account /usr/bin/create-account
+COPY --from=build /out/generate-config /usr/bin/generate-config
+COPY --from=build /out/generate-keys /usr/bin/generate-keys
+COPY --from=build /out/dendrite-demo-pinecone /usr/bin/dendrite-demo-pinecone
 
 VOLUME /etc/dendrite
 WORKDIR /etc/dendrite

--- a/build/docker/Dockerfile.demo-yggdrasil
+++ b/build/docker/Dockerfile.demo-yggdrasil
@@ -1,28 +1,15 @@
-FROM docker.io/golang:1.22-alpine AS base
-
-#
-# Needs to be separate from the main Dockerfile for OpenShift,
-# as --target is not supported there.
-#
-
-RUN apk --update --no-cache add bash build-base
-
-WORKDIR /build
-
-COPY . /build
-
-RUN mkdir -p bin
-RUN go build -trimpath -o bin/ ./cmd/dendrite-demo-yggdrasil
-RUN go build -trimpath -o bin/ ./cmd/create-account
-RUN go build -trimpath -o bin/ ./cmd/generate-keys
+FROM --platform=${BUILDPLATFORM} ghcr.io/element-hq/dendrite:buildcache AS build
 
 FROM alpine:latest
 LABEL org.opencontainers.image.title="Dendrite (Yggdrasil demo)"
 LABEL org.opencontainers.image.description="Next-generation Matrix homeserver written in Go"
 LABEL org.opencontainers.image.source="https://github.com/matrix-org/dendrite"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.licenses="AGPL-3.0-only OR LicenseRef-Element-Commercial"
 
-COPY --from=base /build/bin/* /usr/bin/
+COPY --from=build /out/create-account /usr/bin/create-account
+COPY --from=build /out/generate-config /usr/bin/generate-config
+COPY --from=build /out/generate-keys /usr/bin/generate-keys
+COPY --from=build /out/dendrite-demo-yggdrasil /usr/bin/dendrite-demo-yggdrasil
 
 VOLUME /etc/dendrite
 WORKDIR /etc/dendrite

--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -12,7 +12,7 @@ The `Dockerfile` is a multistage file which can build Dendrite. From the root of
 repository, run:
 
 ```
-docker build . -t matrixdotorg/dendrite-monolith
+docker build -t ghcr.io/element-hq/dendrite-monolith:latest .
 ```
 
 ## Compose file
@@ -36,7 +36,7 @@ To generate keys:
 ```
 docker run --rm --entrypoint="" \
   -v $(pwd):/mnt \
-  matrixdotorg/dendrite-monolith:latest \
+  ghcr.io/element-hq/dendrite-monolith:latest \
   /usr/bin/generate-keys \
   -private-key /mnt/matrix_key.pem \
   -tls-cert /mnt/server.crt \

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   monolith:
     hostname: monolith
-    image: matrixdotorg/dendrite-monolith:latest
+    image: ghcr.io/element-hq/dendrite-monolith:latest
     ports:
       - 8008:8008
       - 8448:8448

--- a/build/docker/images-build.sh
+++ b/build/docker/images-build.sh
@@ -6,6 +6,9 @@ TAG=${1:-latest}
 
 echo "Building tag '${TAG}'"
 
-docker build . --target monolith -t matrixdotorg/dendrite-monolith:${TAG}
-docker build . --target demo-pinecone -t matrixdotorg/dendrite-demo-pinecone:${TAG}
-docker build . --target demo-yggdrasil -t matrixdotorg/dendrite-demo-yggdrasil:${TAG}
+docker build -t ghcr.io/element-hq/dendrite:buildcache --target build .
+
+docker build -t ghcr.io/element-hq/dendrite-monolith:${TAG} .
+
+docker build -t ghcr.io/element-hq/dendrite-demo-yggdrasil:${TAG} -f build/docker/Dockerfile.demo-yggdrasil .
+docker build -t ghcr.io/element-hq/dendrite-demo-pinecone:${TAG} -f build/docker/Dockerfile.demo-pinecone .

--- a/build/docker/images-pull.sh
+++ b/build/docker/images-pull.sh
@@ -4,4 +4,4 @@ TAG=${1:-latest}
 
 echo "Pulling tag '${TAG}'"
 
-docker pull matrixdotorg/dendrite-monolith:${TAG}
+docker pull ghcr.io/element-hq/dendrite-monolith:${TAG}

--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -4,4 +4,4 @@ TAG=${1:-latest}
 
 echo "Pushing tag '${TAG}'"
 
-docker push matrixdotorg/dendrite-monolith:${TAG}
+docker push ghcr.io/element-hq/dendrite-monolith:${TAG}

--- a/docs/installation/docker/1_docker.md
+++ b/docs/installation/docker/1_docker.md
@@ -24,10 +24,10 @@ First we'll generate private key, which is used to sign events, the following wi
 mkdir -p ./config
 docker run --rm --entrypoint="/usr/bin/generate-keys" \
   -v $(pwd)/config:/mnt \
-  matrixdotorg/dendrite-monolith:latest \
+  ghcr.io/element-hq/dendrite-monolith:latest \
   -private-key /mnt/matrix_key.pem
 
-# Windows equivalent: docker run --rm --entrypoint="/usr/bin/generate-keys" -v %cd%/config:/mnt matrixdotorg/dendrite-monolith:latest -private-key /mnt/matrix_key.pem
+# Windows equivalent: docker run --rm --entrypoint="/usr/bin/generate-keys" -v %cd%/config:/mnt ghcr.io/element-hq/dendrite-monolith:latest -private-key /mnt/matrix_key.pem
 ```
 (**NOTE**: This only needs to be executed **once**, as you otherwise overwrite the key)
 
@@ -41,13 +41,13 @@ to the docker-compose file (`services.postgres.environment` values):
 mkdir -p ./config
 docker run --rm --entrypoint="/bin/sh" \
   -v $(pwd)/config:/mnt \
-  matrixdotorg/dendrite-monolith:latest \
+  ghcr.io/element-hq/dendrite-monolith:latest \
   -c "/usr/bin/generate-config \
     -dir /var/dendrite/ \
     -db postgres://dendrite:itsasecret@postgres/dendrite?sslmode=disable \
     -server YourDomainHere > /mnt/dendrite.yaml"
 
-# Windows equivalent: docker run --rm --entrypoint="/bin/sh" -v %cd%/config:/mnt matrixdotorg/dendrite-monolith:latest -c "/usr/bin/generate-config -dir /var/dendrite/ -db postgres://dendrite:itsasecret@postgres/dendrite?sslmode=disable -server YourDomainHere > /mnt/dendrite.yaml"
+# Windows equivalent: docker run --rm --entrypoint="/bin/sh" -v %cd%/config:/mnt ghcr.io/element-hq/dendrite-monolith:latest -c "/usr/bin/generate-config -dir /var/dendrite/ -db postgres://dendrite:itsasecret@postgres/dendrite?sslmode=disable -server YourDomainHere > /mnt/dendrite.yaml"
 ```
 
 You can then change `config/dendrite.yaml` to your liking.


### PR DESCRIPTION
This should significantly speedup building the pinecone and yggdrasil demos, as they now reuse the new `dendrite:buildcache`, which already builds all binaries.