### PR TITLE
MSC3938: Remove `{keyID}` from key lookups over federation

### DIFF
--- a/federationapi/internal/query.go
+++ b/federationapi/internal/query.go
@@ -46,14 +46,14 @@ func (a *FederationInternalAPI) fetchServerKeysFromCache(
 
 	// We got a request for _all_ server keys, return them.
 	if len(req.KeyIDToCriteria) == 0 {
-		serverKeysResponses, _ := a.db.GetNotaryKeys(ctx, req.ServerName, []gomatrixserverlib.KeyID{})
+		serverKeysResponses, _ := a.db.GetNotaryKeys(ctx, req.ServerName)
 		if len(serverKeysResponses) == 0 {
 			return nil, fmt.Errorf("failed to find server key response for server %s", req.ServerName)
 		}
 		return serverKeysResponses, nil
 	}
 	for keyID, criteria := range req.KeyIDToCriteria {
-		serverKeysResponses, _ := a.db.GetNotaryKeys(ctx, req.ServerName, []gomatrixserverlib.KeyID{keyID})
+		serverKeysResponses, _ := a.db.GetNotaryKeys(ctx, req.ServerName)
 		if len(serverKeysResponses) == 0 {
 			return nil, fmt.Errorf("failed to find server key response for key ID %s", keyID)
 		}
@@ -90,7 +90,7 @@ func (a *FederationInternalAPI) QueryServerKeys(
 	if err != nil {
 		// try to load as much as we can from the cache in a best effort basis
 		util.GetLogger(ctx).WithField("server", req.ServerName).WithError(err).Warn("notary: failed to ask server for keys, returning best effort keys")
-		serverKeysResponses, dbErr := a.db.GetNotaryKeys(ctx, req.ServerName, req.KeyIDs())
+		serverKeysResponses, dbErr := a.db.GetNotaryKeys(ctx, req.ServerName)
 		if dbErr != nil {
 			return fmt.Errorf("notary: server returned %s, and db returned %s", err, dbErr)
 		}

--- a/federationapi/storage/interface.go
+++ b/federationapi/storage/interface.go
@@ -73,9 +73,8 @@ type Database interface {
 
 	// Update the notary with the given server keys from the given server name.
 	UpdateNotaryKeys(ctx context.Context, serverName spec.ServerName, serverKeys gomatrixserverlib.ServerKeys) error
-	// Query the notary for the server keys for the given server. If `optKeyIDs` is not empty, multiple server keys may be returned (between 1 - len(optKeyIDs))
-	// such that the combination of all server keys will include all the `optKeyIDs`.
-	GetNotaryKeys(ctx context.Context, serverName spec.ServerName, optKeyIDs []gomatrixserverlib.KeyID) ([]gomatrixserverlib.ServerKeys, error)
+	// Query the notary for the server keys for the given server.
+	GetNotaryKeys(ctx context.Context, serverName spec.ServerName) ([]gomatrixserverlib.ServerKeys, error)
 	// DeleteExpiredEDUs cleans up expired EDUs
 	DeleteExpiredEDUs(ctx context.Context) error
 

--- a/federationapi/storage/shared/storage.go
+++ b/federationapi/storage/shared/storage.go
@@ -358,10 +358,9 @@ func (d *Database) UpdateNotaryKeys(
 func (d *Database) GetNotaryKeys(
 	ctx context.Context,
 	serverName spec.ServerName,
-	optKeyIDs []gomatrixserverlib.KeyID,
 ) (sks []gomatrixserverlib.ServerKeys, err error) {
 	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-		sks, err = d.NotaryServerKeysMetadata.SelectKeys(ctx, txn, serverName, optKeyIDs)
+		sks, err = d.NotaryServerKeysMetadata.SelectKeys(ctx, txn, serverName)
 		return err
 	})
 	return sks, err

--- a/federationapi/storage/tables/interface.go
+++ b/federationapi/storage/tables/interface.go
@@ -121,7 +121,7 @@ type FederationNotaryServerKeysMetadata interface {
 	UpsertKey(ctx context.Context, txn *sql.Tx, serverName spec.ServerName, keyID gomatrixserverlib.KeyID, newNotaryID NotaryID, newValidUntil spec.Timestamp) (NotaryID, error)
 	// SelectKeys returns the signed JSON objects which contain the given key IDs. This will be at most the length of `keyIDs` and at least 1 (assuming
 	// the keys exist in the first place). If `keyIDs` is empty, the signed JSON object with the longest valid_until_ts will be returned.
-	SelectKeys(ctx context.Context, txn *sql.Tx, serverName spec.ServerName, keyIDs []gomatrixserverlib.KeyID) ([]gomatrixserverlib.ServerKeys, error)
+	SelectKeys(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) ([]gomatrixserverlib.ServerKeys, error)
 	// DeleteOldJSONResponses removes all responses which are not referenced in FederationNotaryServerKeysMetadata
 	DeleteOldJSONResponses(ctx context.Context, txn *sql.Tx) error
 }

--- a/test/memory_federation_db.go
+++ b/test/memory_federation_db.go
@@ -492,7 +492,7 @@ func (d *InMemoryFederationDatabase) UpdateNotaryKeys(ctx context.Context, serve
 	return nil
 }
 
-func (d *InMemoryFederationDatabase) GetNotaryKeys(ctx context.Context, serverName spec.ServerName, optKeyIDs []gomatrixserverlib.KeyID) ([]gomatrixserverlib.ServerKeys, error) {
+func (d *InMemoryFederationDatabase) GetNotaryKeys(ctx context.Context, serverName spec.ServerName) ([]gomatrixserverlib.ServerKeys, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
As per MSC3938, which landed in Matrix 1.6 (so this is part of #3224 )

No tests, as this basically only removes code.