### PR TITLE
Add federation whitelist for servers

### DIFF
--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -107,6 +107,22 @@ func NewInternalAPI(
 
 	stats := statistics.NewStatistics(federationDB, cfg.FederationMaxRetries+1, cfg.P2PFederationRetriesUntilAssumedOffline+1, cfg.EnableRelays)
 
+	// Add servers to whitelist if enabled
+	if cfg.EnableWhitelist {
+		// We need to clear the list of the whitelisted servers during init
+		err = stats.DB.RemoveAllServersFromWhitelist()
+		if err != nil {
+			logrus.WithError(err).Panic("failed to clear whitelisted servers")
+		}
+		// Add each whitelisted server to the database
+		for _, server := range cfg.WhitelistedServers {
+			err = stats.DB.AddServerToWhitelist(server)
+			if err != nil {
+				logrus.WithError(err).Panicf("failed to add server %s to whitelist", server)
+			}
+		}
+	}
+
 	js, nats := natsInstance.Prepare(processContext, &cfg.Matrix.JetStream)
 
 	signingInfo := dendriteCfg.Global.SigningIdentities()

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -114,7 +114,8 @@ func NewInternalAPI(
 		if err != nil {
 			logrus.WithError(err).Panic("failed to clear whitelisted servers")
 		}
-		// Add each whitelisted server to the database
+
+		// Add each whitelisted server to the data
 		for _, server := range cfg.WhitelistedServers {
 			err = stats.DB.AddServerToWhitelist(server)
 			if err != nil {

--- a/federationapi/internal/api.go
+++ b/federationapi/internal/api.go
@@ -112,6 +112,12 @@ func NewFederationInternalAPI(
 	}
 }
 
+// IsWhitelistedOrAny checks if the server is whitelisted or the whitelist is disabled, so we can connect to any server
+func (a *FederationInternalAPI) IsWhitelistedOrAny(s spec.ServerName) bool {
+	stats := a.statistics.ForServer(s)
+	return stats.Whitelisted() || !a.cfg.EnableWhitelist
+}
+
 func (a *FederationInternalAPI) IsBlacklistedOrBackingOff(s spec.ServerName) (*statistics.ServerStatistics, error) {
 	stats := a.statistics.ForServer(s)
 	if stats.Blacklisted() {

--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -44,6 +44,9 @@ func (a *FederationInternalAPI) GetEventAuth(
 ) (res fclient.RespEventAuth, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespEventAuth{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.GetEventAuth(ctx, origin, s, roomVersion, roomID, eventID)
 	})
@@ -58,6 +61,9 @@ func (a *FederationInternalAPI) GetUserDevices(
 ) (fclient.RespUserDevices, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespUserDevices{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.GetUserDevices(ctx, origin, s, userID)
 	})
@@ -72,6 +78,9 @@ func (a *FederationInternalAPI) ClaimKeys(
 ) (fclient.RespClaimKeys, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespClaimKeys{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.ClaimKeys(ctx, origin, s, oneTimeKeys)
 	})
@@ -84,6 +93,9 @@ func (a *FederationInternalAPI) ClaimKeys(
 func (a *FederationInternalAPI) QueryKeys(
 	ctx context.Context, origin, s spec.ServerName, keys map[string][]string,
 ) (fclient.RespQueryKeys, error) {
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespQueryKeys{}, nil
+	}
 	ires, err := a.doRequestIfNotBackingOffOrBlacklisted(s, func() (interface{}, error) {
 		return a.federation.QueryKeys(ctx, origin, s, keys)
 	})
@@ -98,6 +110,9 @@ func (a *FederationInternalAPI) Backfill(
 ) (res gomatrixserverlib.Transaction, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return gomatrixserverlib.Transaction{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.Backfill(ctx, origin, s, roomID, limit, eventIDs)
 	})
@@ -112,6 +127,9 @@ func (a *FederationInternalAPI) LookupState(
 ) (res gomatrixserverlib.StateResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return &fclient.RespState{}, nil
+	} // TODO check &
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupState(ctx, origin, s, roomID, eventID, roomVersion)
 	})
@@ -127,6 +145,9 @@ func (a *FederationInternalAPI) LookupStateIDs(
 ) (res gomatrixserverlib.StateIDResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespStateIDs{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupStateIDs(ctx, origin, s, roomID, eventID)
 	})
@@ -142,6 +163,9 @@ func (a *FederationInternalAPI) LookupMissingEvents(
 ) (res fclient.RespMissingEvents, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return fclient.RespMissingEvents{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupMissingEvents(ctx, origin, s, roomID, missing, roomVersion)
 	})
@@ -156,6 +180,9 @@ func (a *FederationInternalAPI) GetEvent(
 ) (res gomatrixserverlib.Transaction, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return gomatrixserverlib.Transaction{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.GetEvent(ctx, origin, s, eventID)
 	})
@@ -170,6 +197,9 @@ func (a *FederationInternalAPI) LookupServerKeys(
 ) ([]gomatrixserverlib.ServerKeys, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return []gomatrixserverlib.ServerKeys{}, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupServerKeys(ctx, s, keyRequests)
 	})
@@ -185,6 +215,9 @@ func (a *FederationInternalAPI) MSC2836EventRelationships(
 ) (res fclient.MSC2836EventRelationshipsResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return res, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.MSC2836EventRelationships(ctx, origin, s, r, roomVersion)
 	})
@@ -199,6 +232,9 @@ func (a *FederationInternalAPI) RoomHierarchies(
 ) (res fclient.RoomHierarchyResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
+	if !a.IsWhitelistedOrAny(s) {
+		return res, nil
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.RoomHierarchy(ctx, origin, s, roomID, suggestedOnly)
 	})

--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -129,7 +129,7 @@ func (a *FederationInternalAPI) LookupState(
 	defer cancel()
 	if !a.IsWhitelistedOrAny(s) {
 		return &fclient.RespState{}, nil
-	} // TODO check &
+	}
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupState(ctx, origin, s, roomID, eventID, roomVersion)
 	})

--- a/federationapi/internal/query.go
+++ b/federationapi/internal/query.go
@@ -86,6 +86,10 @@ func (a *FederationInternalAPI) QueryServerKeys(
 	}
 	util.GetLogger(ctx).WithField("server", req.ServerName).WithError(err).Warn("notary: failed to satisfy keys request entirely from cache, hitting direct")
 
+	if !a.IsWhitelistedOrAny(req.ServerName) {
+		return nil
+	}
+
 	serverKeys, err := a.fetchServerKeysDirectly(ctx, req.ServerName)
 	if err != nil {
 		// try to load as much as we can from the cache in a best effort basis

--- a/federationapi/storage/interface.go
+++ b/federationapi/storage/interface.go
@@ -49,6 +49,11 @@ type Database interface {
 	RemoveAllServersFromBlacklist() error
 	IsServerBlacklisted(serverName spec.ServerName) (bool, error)
 
+	AddServerToWhitelist(serverName spec.ServerName) error
+	RemoveServerFromWhitelist(serverName spec.ServerName) error
+	RemoveAllServersFromWhitelist() error
+	IsServerWhitelisted(serverName spec.ServerName) (bool, error)
+
 	// Adds the server to the list of assumed offline servers.
 	// If the server already exists in the table, nothing happens and returns success.
 	SetServerAssumedOffline(ctx context.Context, serverName spec.ServerName) error

--- a/federationapi/storage/postgres/storage.go
+++ b/federationapi/storage/postgres/storage.go
@@ -38,6 +38,10 @@ func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties 
 	if err != nil {
 		return nil, err
 	}
+	whitelist, err := NewPostgresWhitelistTable(d.db)
+	if err != nil {
+		return nil, err
+	}
 	joinedHosts, err := NewPostgresJoinedHostsTable(d.db)
 	if err != nil {
 		return nil, err
@@ -104,6 +108,7 @@ func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties 
 		FederationQueueEDUs:      queueEDUs,
 		FederationQueueJSON:      queueJSON,
 		FederationBlacklist:      blacklist,
+		FederationWhitelist:      whitelist,
 		FederationAssumedOffline: assumedOffline,
 		FederationRelayServers:   relayServers,
 		FederationInboundPeeks:   inboundPeeks,

--- a/federationapi/storage/postgres/whitelist_table.go
+++ b/federationapi/storage/postgres/whitelist_table.go
@@ -1,0 +1,93 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/element-hq/dendrite/internal/sqlutil"
+	"github.com/matrix-org/gomatrixserverlib/spec"
+)
+
+const whitelistSchema = `
+CREATE TABLE IF NOT EXISTS federationsender_whitelist (
+    -- The whitelisted server name
+	server_name TEXT NOT NULL,
+	UNIQUE (server_name)
+`
+
+const insertWhitelistSQL = "" +
+	"INSERT INTO federationsender_whitelist (server_name) VALUES ($1)" +
+	" ON CONFLICT DO NOTHING"
+
+const selectWhitelistSQL = "" +
+	"SELECT server_name FROM federationsender_whitelist WHERE server_name = $1"
+
+const deleteWhitelistSQL = "" +
+	"DELETE FROM federationsender_whitelist WHERE server_name = $1"
+
+const deleteAllWhitelistSQL = "" +
+	"TRUNCATE federationsender_whitelist"
+
+type whitelistStatements struct {
+	db                     *sql.DB
+	insertWhitelistStmt    *sql.Stmt
+	selectWhitelistStmt    *sql.Stmt
+	deleteWhitelistStmt    *sql.Stmt
+	deleteAllWhitelistStmt *sql.Stmt
+}
+
+func NewPostgresWhitelistTable(db *sql.DB) (s *whitelistStatements, err error) {
+	s = &whitelistStatements{
+		db: db,
+	}
+	_, err = db.Exec(whitelistSchema)
+	if err != nil {
+		return
+	}
+
+	return s, sqlutil.StatementList{
+		{&s.insertWhitelistStmt, insertWhitelistSQL},
+		{&s.selectWhitelistStmt, selectWhitelistSQL},
+		{&s.deleteWhitelistStmt, deleteWhitelistSQL},
+		{&s.deleteAllWhitelistStmt, deleteAllWhitelistSQL},
+	}.Prepare(db)
+}
+
+func (s *whitelistStatements) InsertWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.insertWhitelistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
+}
+
+func (s *whitelistStatements) SelectWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) (bool, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectWhitelistStmt)
+	res, err := stmt.QueryContext(ctx, serverName)
+	if err != nil {
+		return false, err
+	}
+	defer res.Close() // nolint:errcheck
+	// The query will return the server name if the server is whitelisted, and
+	// will return no rows if not. By calling Next, we find out if a row was
+	// returned or not - we don't care about the value itself.
+	return res.Next(), nil
+}
+
+func (s *whitelistStatements) DeleteWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteWhitelistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
+}
+
+func (s *whitelistStatements) DeleteAllWhitelist(
+	ctx context.Context, txn *sql.Tx,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteAllWhitelistStmt)
+	_, err := stmt.ExecContext(ctx)
+	return err
+}

--- a/federationapi/storage/postgres/whitelist_table.go
+++ b/federationapi/storage/postgres/whitelist_table.go
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS federationsender_whitelist (
     -- The whitelisted server name
 	server_name TEXT NOT NULL,
 	UNIQUE (server_name)
+);
 `
 
 const insertWhitelistSQL = "" +

--- a/federationapi/storage/shared/storage.go
+++ b/federationapi/storage/shared/storage.go
@@ -31,6 +31,7 @@ type Database struct {
 	FederationQueueJSON      tables.FederationQueueJSON
 	FederationJoinedHosts    tables.FederationJoinedHosts
 	FederationBlacklist      tables.FederationBlacklist
+	FederationWhitelist      tables.FederationWhitelist
 	FederationAssumedOffline tables.FederationAssumedOffline
 	FederationRelayServers   tables.FederationRelayServers
 	FederationOutboundPeeks  tables.FederationOutboundPeeks
@@ -148,11 +149,27 @@ func (d *Database) AddServerToBlacklist(
 	})
 }
 
+func (d *Database) AddServerToWhitelist(
+	serverName spec.ServerName,
+) error {
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.FederationWhitelist.InsertWhitelist(context.TODO(), txn, serverName)
+	})
+}
+
 func (d *Database) RemoveServerFromBlacklist(
 	serverName spec.ServerName,
 ) error {
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		return d.FederationBlacklist.DeleteBlacklist(context.TODO(), txn, serverName)
+	})
+}
+
+func (d *Database) RemoveServerFromWhitelist(
+	serverName spec.ServerName,
+) error {
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.FederationWhitelist.DeleteWhitelist(context.TODO(), txn, serverName)
 	})
 }
 
@@ -162,10 +179,22 @@ func (d *Database) RemoveAllServersFromBlacklist() error {
 	})
 }
 
+func (d *Database) RemoveAllServersFromWhitelist() error {
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.FederationWhitelist.DeleteAllWhitelist(context.TODO(), txn)
+	})
+}
+
 func (d *Database) IsServerBlacklisted(
 	serverName spec.ServerName,
 ) (bool, error) {
 	return d.FederationBlacklist.SelectBlacklist(context.TODO(), nil, serverName)
+}
+
+func (d *Database) IsServerWhitelisted(
+	serverName spec.ServerName,
+) (bool, error) {
+	return d.FederationWhitelist.SelectWhitelist(context.TODO(), nil, serverName)
 }
 
 func (d *Database) SetServerAssumedOffline(

--- a/federationapi/storage/sqlite3/storage.go
+++ b/federationapi/storage/sqlite3/storage.go
@@ -36,6 +36,10 @@ func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties 
 	if err != nil {
 		return nil, err
 	}
+	whitelist, err := NewSQLiteWhitelistTable(d.db)
+	if err != nil {
+		return nil, err
+	}
 	joinedHosts, err := NewSQLiteJoinedHostsTable(d.db)
 	if err != nil {
 		return nil, err
@@ -102,6 +106,7 @@ func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties 
 		FederationQueueEDUs:      queueEDUs,
 		FederationQueueJSON:      queueJSON,
 		FederationBlacklist:      blacklist,
+		FederationWhitelist:      whitelist,
 		FederationAssumedOffline: assumedOffline,
 		FederationRelayServers:   relayServers,
 		FederationOutboundPeeks:  outboundPeeks,

--- a/federationapi/storage/sqlite3/whitelist_table.go
+++ b/federationapi/storage/sqlite3/whitelist_table.go
@@ -1,0 +1,94 @@
+package sqlite3
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/element-hq/dendrite/internal/sqlutil"
+	"github.com/matrix-org/gomatrixserverlib/spec"
+)
+
+const whitelistSchema = `
+CREATE TABLE IF NOT EXISTS federationsender_whitelist (
+    -- The whitelisted server name
+	server_name TEXT NOT NULL,
+	UNIQUE (server_name)
+);
+`
+
+const insertWhitelistSQL = "" +
+	"INSERT INTO federationsender_whitelist (server_name) VALUES ($1)" +
+	" ON CONFLICT DO NOTHING"
+
+const selectWhitelistSQL = "" +
+	"SELECT server_name FROM federationsender_whitelist WHERE server_name = $1"
+
+const deleteWhitelistSQL = "" +
+	"DELETE FROM federationsender_whitelist WHERE server_name = $1"
+
+const deleteAllWhitelistSQL = "" +
+	"DELETE FROM federationsender_whitelist"
+
+type whitelistStatements struct {
+	db                     *sql.DB
+	insertWhitelistStmt    *sql.Stmt
+	selectWhitelistStmt    *sql.Stmt
+	deleteWhitelistStmt    *sql.Stmt
+	deleteAllWhitelistStmt *sql.Stmt
+}
+
+func NewSQLiteWhitelistTable(db *sql.DB) (s *whitelistStatements, err error) {
+	s = &whitelistStatements{
+		db: db,
+	}
+	_, err = db.Exec(whitelistSchema)
+	if err != nil {
+		return
+	}
+
+	return s, sqlutil.StatementList{
+		{&s.insertWhitelistStmt, insertWhitelistSQL},
+		{&s.selectWhitelistStmt, selectWhitelistSQL},
+		{&s.deleteWhitelistStmt, deleteWhitelistSQL},
+		{&s.deleteAllWhitelistStmt, deleteAllWhitelistSQL},
+	}.Prepare(db)
+}
+
+func (s *whitelistStatements) InsertWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.insertWhitelistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
+}
+
+func (s *whitelistStatements) SelectWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) (bool, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectWhitelistStmt)
+	res, err := stmt.QueryContext(ctx, serverName)
+	if err != nil {
+		return false, err
+	}
+	defer res.Close() // nolint:errcheck
+	// The query will return the server name if the server is whitelisted, and
+	// will return no rows if not. By calling Next, we find out if a row was
+	// returned or not - we don't care about the value itself.
+	return res.Next(), nil
+}
+
+func (s *whitelistStatements) DeleteWhitelist(
+	ctx context.Context, txn *sql.Tx, serverName spec.ServerName,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteWhitelistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
+}
+
+func (s *whitelistStatements) DeleteAllWhitelist(
+	ctx context.Context, txn *sql.Tx,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteAllWhitelistStmt)
+	_, err := stmt.ExecContext(ctx)
+	return err
+}

--- a/federationapi/storage/tables/interface.go
+++ b/federationapi/storage/tables/interface.go
@@ -72,6 +72,13 @@ type FederationBlacklist interface {
 	DeleteAllBlacklist(ctx context.Context, txn *sql.Tx) error
 }
 
+type FederationWhitelist interface {
+	InsertWhitelist(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) error
+	SelectWhitelist(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) (bool, error)
+	DeleteWhitelist(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) error
+	DeleteAllWhitelist(ctx context.Context, txn *sql.Tx) error
+}
+
 type FederationAssumedOffline interface {
 	InsertAssumedOffline(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) error
 	SelectAssumedOffline(ctx context.Context, txn *sql.Tx, serverName spec.ServerName) (bool, error)

--- a/setup/config/config_federationapi.go
+++ b/setup/config/config_federationapi.go
@@ -46,6 +46,12 @@ type FederationAPI struct {
 
 	// Should we prefer direct key fetches over perspective ones?
 	PreferDirectFetch bool `yaml:"prefer_direct_fetch"`
+
+	// Enable servers whitelist function
+	EnableWhitelist bool `yaml:"enable_whitelist"`
+
+	// The list of whitelisted servers
+	WhitelistedServers []spec.ServerName `yaml:"whitelisted_servers"`
 }
 
 func (c *FederationAPI) Defaults(opts DefaultOpts) {
@@ -73,6 +79,8 @@ func (c *FederationAPI) Defaults(opts DefaultOpts) {
 			c.Database.ConnectionString = "file:federationapi.db"
 		}
 	}
+	c.EnableWhitelist = false
+	c.WhitelistedServers = make([]spec.ServerName, 0)
 }
 
 func (c *FederationAPI) Verify(configErrs *ConfigErrors) {

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -96,6 +96,8 @@ client_api:
 federation_api:
   database:
     connection_string: file:federationapi.db
+  enable_whitelist: true
+  whitelisted_servers: ["https://matrix.org"]
 key_server:
   database:
     connection_string: file:keyserver.db


### PR DESCRIPTION
### Description

This PR introduces a mechanism to exclude all servers from federation except given ones. Similar functionality is implemented in Synapse [using federation_domain_whitelist](https://matrix-org.github.io/synapse/latest/usage/configuration/config_documentation.html#federation_domain_whitelist)

### Configuration

In `federation`:
- `enable_whitelist`: enable or disable whitelist
- `whitelisted_servers`: the list of server names to whitelist

### Changes

- Added new table with the list of whitelisted servers
- Added necessary APIs for accessing this server property
- The whitelist check is performed in `federationapi/internal/federationclient.go`

### Pull Request Checklist

* [ ] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [ ] Pull request includes a [sign off below](https://element-hq.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Sign-off: private
