### PR TITLE
Demote `wakeQueueIfEventsPending` and thumbnailer log lines to debug

### DIFF
--- a/federationapi/queue/destinationqueue.go
+++ b/federationapi/queue/destinationqueue.go
@@ -147,7 +147,7 @@ func (oq *destinationQueue) wakeQueueIfEventsPending(forceWakeup bool) {
 	// or if forceWakeup is true. Otherwise there is no reason to start the
 	// queue goroutine and waste resources.
 	if forceWakeup || eventsPending() {
-		logrus.Info("Starting queue due to pending events or forceWakeup")
+		logrus.Debugf("Starting queue %q -> %q due to pending events or forceWakeup", oq.origin, oq.destination)
 		oq.wakeQueueAndNotify()
 	}
 }

--- a/mediaapi/thumbnailer/thumbnailer.go
+++ b/mediaapi/thumbnailer/thumbnailer.go
@@ -86,7 +86,7 @@ func getActiveThumbnailGeneration(dst types.Path, _ types.ThumbnailSize, activeT
 	activeThumbnailGeneration.Lock()
 	defer activeThumbnailGeneration.Unlock()
 	if activeThumbnailGenerationResult, ok := activeThumbnailGeneration.PathToResult[string(dst)]; ok {
-		logger.Info("Waiting for another goroutine to generate the thumbnail.")
+		logger.Debugf("Waiting for another goroutine to generate the thumbnail %q", dst)
 
 		// NOTE: Wait unlocks and locks again internally. There is still a deferred Unlock() that will unlock this.
 		activeThumbnailGenerationResult.Cond.Wait()
@@ -115,7 +115,7 @@ func broadcastGeneration(dst types.Path, activeThumbnailGeneration *types.Active
 	activeThumbnailGeneration.Lock()
 	defer activeThumbnailGeneration.Unlock()
 	if activeThumbnailGenerationResult, ok := activeThumbnailGeneration.PathToResult[string(dst)]; ok {
-		logger.Info("Signalling other goroutines waiting for this goroutine to generate the thumbnail.")
+		logger.Debugf("Signalling other goroutines waiting for this goroutine to generate the thumbnail %q", dst)
 		// Note: errorReturn is a named return value error that is signalled from here to waiting goroutines
 		activeThumbnailGenerationResult.Err = errorReturn
 		activeThumbnailGenerationResult.Cond.Broadcast()
@@ -136,7 +136,7 @@ func isThumbnailExists(
 		config.Width, config.Height, config.ResizeMethod,
 	)
 	if err != nil {
-		logger.Error("Failed to query database for thumbnail.")
+		logger.Errorf("Failed to query database for thumbnail %q", dst)
 		return false, err
 	}
 	if thumbnailMetadata != nil {

--- a/mediaapi/thumbnailer/thumbnailer_bimg.go
+++ b/mediaapi/thumbnailer/thumbnailer_bimg.go
@@ -153,7 +153,7 @@ func createThumbnail(
 		"ActualWidth":  width,
 		"ActualHeight": height,
 		"processTime":  time.Now().Sub(start),
-	}).Info("Generated thumbnail")
+	}).Debugf("Generated thumbnail %q", dst)
 
 	stat, err := os.Stat(string(dst))
 	if err != nil {

--- a/mediaapi/thumbnailer/thumbnailer_nfnt.go
+++ b/mediaapi/thumbnailer/thumbnailer_nfnt.go
@@ -191,7 +191,7 @@ func createThumbnail(
 		"ActualWidth":  width,
 		"ActualHeight": height,
 		"processTime":  time.Since(start),
-	}).Info("Generated thumbnail")
+	}).Debugf("Generated thumbnail %q", dst)
 
 	stat, err := os.Stat(string(dst))
 	if err != nil {


### PR DESCRIPTION
This just produces a lot of noise in the logs for no reason and they didn't even say which queues or thumbnails were relevant.

Signed-off-by: Neil Alexander <git@neilalexander.dev>