### PR TITLE
Add HaProxy conf with/without TLS termination

### DIFF
--- a/docs/haproxy/haproxy-with-tls-termination.cfg
+++ b/docs/haproxy/haproxy-with-tls-termination.cfg
@@ -1,0 +1,26 @@
+backend be_matrix
+    mode http
+# Dendrite running on same host:
+    server static 127.0.0.1:8008 check
+# For Dendrite running on host with ip a.b.c.d, replace with:
+#    server static a.b.c.d:8008 check
+
+backend matrix-well-known-client
+  http-after-response set-header Access-Control-Allow-Origin "*"
+  http-after-response set-header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+  http-after-response set-header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+url":"https://identity.example.com"}}'
+  http-request return status 200 content-type application/json string '{"m.homeserver":{"base_url":"https://matrix.example.com"},"m.identity_server":{"base_u
+rl":"https://matrix.example.com"}}'
+
+backend matrix-well-known-server
+  http-after-response set-header Access-Control-Allow-Origin "*"
+  http-after-response set-header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+  http-after-response set-header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  http-request return status 200 content-type application/json string '{"m.server":"matrix.example.com"}'
+
+frontend fe_matrix_dendrite
+# Replace   123.123.123.123 with your PUBLIC ip address
+    bind 123.123.123.123:8448 ssl crt /etc/haproxy/certs/matrix.example.com.pem
+    use_backend     be_matrix
+    default_backend be_matrix

--- a/docs/haproxy/haproxy.cfg
+++ b/docs/haproxy/haproxy.cfg
@@ -1,0 +1,26 @@
+backend be_matrix
+    mode http
+# Dendrite running on same host:
+    server static 127.0.0.1:8448 check
+# For Dendrite running on host with ip a.b.c.d, replace with:
+#    server static a.b.c.d:8448 check
+
+backend matrix-well-known-client
+  http-after-response set-header Access-Control-Allow-Origin "*"
+  http-after-response set-header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+  http-after-response set-header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+url":"https://identity.example.com"}}'
+  http-request return status 200 content-type application/json string '{"m.homeserver":{"base_url":"https://matrix.example.com"},"m.identity_server":{"base_u
+rl":"https://matrix.example.com"}}'
+
+backend matrix-well-known-server
+  http-after-response set-header Access-Control-Allow-Origin "*"
+  http-after-response set-header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
+  http-after-response set-header Access-Control-Allow-Headers "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  http-request return status 200 content-type application/json string '{"m.server":"matrix.example.com"}'
+
+frontend fe_matrix_dendrite
+# Replace   123.123.123.123 with your PUBLIC ip address
+    bind 123.123.123.123:8448 
+    use_backend     be_matrix
+    default_backend be_matrix


### PR DESCRIPTION
### Pull Request Checklist

The PR documents how to use HaProxy as reverse proxy towards Dendrite in the following 2 scenarios:
- with TLS termination
- without TLS termination

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [ ] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x ] Pull request includes a [sign off below](https://element-hq.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Paolo Lulli <paolo@lulli.net>`
