### PR TITLE
[notifications] Give each HTTP request its own context

### DIFF
--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -604,7 +604,9 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstype
 	// ordering guarantees we must provide.
 	go func() {
 		// This background processing cannot be tied to a request.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second*time.Duration(len(devicesByURLAndFormat)))
+		// We're generous with the "global" timeout, each HTTP request gets its own context with
+		// at most 30 seconds below.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
 		var rejected []*pushgateway.Device
@@ -615,16 +617,16 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstype
 					continue
 				}
 
-				// Give each HTTP request its own context.
-				httpCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-
 				// UNSPEC: the specification suggests there can be
 				// more than one device per request. There is at least
 				// one Sytest that expects one HTTP request per
 				// device, rather than per URL. For now, we must
 				// notify each one separately.
 				for _, dev := range devices {
+					// Give each HTTP request its own context.
+					httpCtx, httpCancel := context.WithTimeout(ctx, 30*time.Second)
 					rej, err := s.notifyHTTP(httpCtx, event, url, format, []*pushgateway.Device{dev}, mem.Localpart, roomName, int(userNumUnreadNotifs))
+					httpCancel()
 					if err != nil {
 						log.WithFields(log.Fields{
 							"event_id":  event.EventID(),
@@ -634,8 +636,6 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstype
 					}
 					rejected = append(rejected, rej...)
 				}
-				// Cancel the context for this URL to free up resources.
-				cancel()
 			}
 		}
 

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -617,7 +617,6 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstype
 
 				// Give each HTTP request its own context.
 				httpCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				defer cancel()
 
 				// UNSPEC: the specification suggests there can be
 				// more than one device per request. There is at least
@@ -635,6 +634,8 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstype
 					}
 					rejected = append(rejected, rej...)
 				}
+				// Cancel the context for this URL to free up resources.
+				cancel()
 			}
 		}
 


### PR DESCRIPTION
Give each HTTP request its own context to avoid timing out subsequent notification requests if the first already times out.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [ ] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below](https://element-hq.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

