### PR TITLE
v0.15.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Dendrite 0.15.1 (2025-08-13)
+
+### Bug fixes
+ - Fixed an issue which could cause Dendrite to become unresponsive for minutes at a time. (contributed by [viviicat](https://github.com/viviicat))
+
 ## Dendrite 0.15.0 (2025-08-12)
 
 ### ⚠ Important

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 ### Bug fixes
  - Fixed an issue which could cause Dendrite to become unresponsive for minutes at a time. (contributed by [viviicat](https://github.com/viviicat))
  - Fixed an issue which prevented joining v12 rooms in some circumstances.
+ - Fixed an issue which prevented sending invites to v12 rooms.
+ - Fixed an issue which prevented some clients from syncing v12 rooms.
  - Fixed an issue where a single badly formed PDU would block entire transactions of PDUs being processed. See https://github.com/element-hq/synapse/issues/7543 for the related issue on Synapse.
 
 ## Dendrite 0.15.0 (2025-08-12)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
  - Fixed an issue which could cause Dendrite to become unresponsive for minutes at a time. (contributed by [viviicat](https://github.com/viviicat))
+ - Fixed an issue which prevented joining v12 rooms in some circumstances.
+ - Fixed an issue where a single badly formed PDU would block entire transactions of PDUs being processed. See https://github.com/element-hq/synapse/issues/7543 for the related issue on Synapse.
 
 ## Dendrite 0.15.0 (2025-08-12)
 

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -575,6 +575,7 @@ func (r *FederationInternalAPI) SendInvite(
 		"room_version": event.Version(),
 		"destination":  destination,
 	}).Info("Sending invite")
+	logrus.Infof("invite event json %s", string(event.JSON()))
 
 	inviteReq, err := fclient.NewInviteV2Request(event, strippedState)
 	if err != nil {

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -575,7 +575,6 @@ func (r *FederationInternalAPI) SendInvite(
 		"room_version": event.Version(),
 		"destination":  destination,
 	}).Info("Sending invite")
-	logrus.Infof("invite event json %s", string(event.JSON()))
 
 	inviteReq, err := fclient.NewInviteV2Request(event, strippedState)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea
 	github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813123338-6029db28e244
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714
 	github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744
 	github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.28

--- a/go.sum
+++ b/go.sum
@@ -237,10 +237,6 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91 h1:s7fexw
 github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8r4Fzarl4+Y3K5hjothkVW5z7T1dUM11U=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250811193806-b7e0e0824751 h1:x1pC7Nt1Qb24q9WtPybMHWo2uVFTzCKtlUAzarju8bk=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250811193806-b7e0e0824751/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813123338-6029db28e244 h1:7pKFuVhn2JkrQBhH14fsIbTd/uBjC5Xu6aIo13oMBEI=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813123338-6029db28e244/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714 h1:AmcvbiZLBWPTAy9d/SitZvbDPTDS6vSdJk+wabfTGgE=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7 h1:6t8kJr8i1/1I5nNttw6nn1ryQJgzVlBmSGgPiiaTdw4=

--- a/go.sum
+++ b/go.sum
@@ -237,10 +237,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91 h1:s7fexw
 github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8r4Fzarl4+Y3K5hjothkVW5z7T1dUM11U=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714 h1:AmcvbiZLBWPTAy9d/SitZvbDPTDS6vSdJk+wabfTGgE=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea h1:FSc9Ik147BXMW+P8RDBWBYNKdGziTO5Vm5dZlwlKX0k=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744 h1:5GvC2FD9O/PhuyY95iJQdNYHbDioEhMWdeMP9maDUL8=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813150445-9f5070a65744/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7 h1:6t8kJr8i1/1I5nNttw6nn1ryQJgzVlBmSGgPiiaTdw4=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7/go.mod h1:ReWMS/LoVnOiRAdq9sNUC2NZnd1mZkMNB52QhpTRWjg=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,8 @@ github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714 h1:AmcvbiZLBWPTAy9d/SitZvbDPTDS6vSdJk+wabfTGgE=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea h1:FSc9Ik147BXMW+P8RDBWBYNKdGziTO5Vm5dZlwlKX0k=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813144341-908a63a3eeea/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7 h1:6t8kJr8i1/1I5nNttw6nn1ryQJgzVlBmSGgPiiaTdw4=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7/go.mod h1:ReWMS/LoVnOiRAdq9sNUC2NZnd1mZkMNB52QhpTRWjg=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20250811193806-b7e0e0824751 h1:x1
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250811193806-b7e0e0824751/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813123338-6029db28e244 h1:7pKFuVhn2JkrQBhH14fsIbTd/uBjC5Xu6aIo13oMBEI=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250813123338-6029db28e244/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714 h1:AmcvbiZLBWPTAy9d/SitZvbDPTDS6vSdJk+wabfTGgE=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20250813131115-3c641bb19714/go.mod h1:b6KVfDjXjA5Q7vhpOaMqIhFYvu5BuFVZixlNeTV/CLc=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7 h1:6t8kJr8i1/1I5nNttw6nn1ryQJgzVlBmSGgPiiaTdw4=
 github.com/matrix-org/pinecone v0.11.1-0.20230810010612-ea4c33717fd7/go.mod h1:ReWMS/LoVnOiRAdq9sNUC2NZnd1mZkMNB52QhpTRWjg=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/internal/version.go
+++ b/internal/version.go
@@ -18,7 +18,7 @@ var build string
 const (
 	VersionMajor = 0
 	VersionMinor = 15
-	VersionPatch = 0
+	VersionPatch = 1
 	VersionTag   = "" // example: "rc1"
 
 	gitRevLen = 7 // 7 matches the displayed characters on github.com

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -31,7 +31,11 @@ type QueryState struct {
 }
 
 func (q *QueryState) GetAuthEvents(ctx context.Context, event gomatrixserverlib.PDU) (gomatrixserverlib.AuthEventProvider, error) {
-	return helpers.GetAuthEvents(ctx, q.Database, event.Version(), event, event.AuthEventIDs())
+	authEventIDs := event.AuthEventIDs()
+	if gomatrixserverlib.MustGetRoomVersion(event.Version()).DomainlessRoomIDs() {
+		authEventIDs = append(authEventIDs, "$"+event.RoomID().String()[1:])
+	}
+	return helpers.GetAuthEvents(ctx, q.Database, event.Version(), event, authEventIDs)
 }
 
 func (q *QueryState) GetState(ctx context.Context, roomID spec.RoomID, stateWanted []gomatrixserverlib.StateKeyTuple) ([]gomatrixserverlib.PDU, error) {

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -404,7 +404,9 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	// "state" section and kept in "timeline".
 	sEvents := gomatrixserverlib.HeaderedReverseTopologicalOrdering(
 		gomatrixserverlib.ToPDUs(removeDuplicates(delta.StateEvents, events)),
-		gomatrixserverlib.TopologicalOrderByAuthEvents,
+		// sorting by auth events is not stable unless we know the create and historical PL events,
+		// which we don't for deltas like this.
+		gomatrixserverlib.TopologicalOrderByPrevEvents,
 	)
 	delta.StateEvents = make([]*rstypes.HeaderedEvent, len(sEvents))
 	var skipped int

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -22,3 +22,7 @@ Guest users can accept invites to private rooms over federation
 # Tests Synapse specific behavior
 /state returns M_NOT_FOUND for an outlier
 /state_ids returns M_NOT_FOUND for an outlier
+
+# this is a silly restriction as it basically stops servers from communicating, so we relax it
+# see https://github.com/element-hq/synapse/issues/7543
+Server rejects invalid JSON in a version 6 room


### PR DESCRIPTION
To pull in https://github.com/element-hq/dendrite/pull/3630

Also pulls in a bunch of bug fixes on v12 rooms, which testing did not catch.

`FAILURE: #655: Server rejects invalid JSON in a version 6 room` is an expected fail now.