### PR TITLE
Bump `go` to 1.25 in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # base installs required dependencies and runs go mod download to cache dependencies
 #
-FROM --platform=${BUILDPLATFORM} docker.io/golang:1.24-alpine AS base
+FROM --platform=${BUILDPLATFORM} docker.io/golang:1.25-alpine AS base
 RUN apk --update --no-cache add bash build-base curl git
 
 #


### PR DESCRIPTION
Required to support upgrading `golang.com/x/image` to 0.38.0 in the Complement repo: https://github.com/matrix-org/complement/pull/854#issuecomment-4177133941

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [ ] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below](https://element-hq.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately
