### PR TITLE
sqlutil: enable WAL, larger cache, and NORMAL sync for the modernc SQLite driver

### DIFF
--- a/internal/sqlutil/sqlite_native.go
+++ b/internal/sqlutil/sqlite_native.go
@@ -20,5 +20,26 @@ func sqliteDSNExtension(dsn string) string {
 	// wait some time before erroring if the db is locked
 	// https://gitlab.com/cznic/sqlite/-/issues/106#note_1058094993
 	dsn += "_pragma=busy_timeout%3d10000"
+
+	// WAL mode lets readers proceed while a writer is active and is the
+	// SQLite-recommended setting for any application with concurrent
+	// readers and writers, which Dendrite's storage layer always is.
+	// https://www.sqlite.org/wal.html
+	dsn += "&_pragma=journal_mode%3dWAL"
+
+	// 32 MiB page cache. The pure-Go SQLite default of 2 MiB results in
+	// excessive page evictions for federation and sync workloads where
+	// many rooms are touched per request. Negative value = KiB.
+	// https://www.sqlite.org/pragma.html#pragma_cache_size
+	dsn += "&_pragma=cache_size%3d-32000"
+
+	// NORMAL fsyncs only at WAL checkpoints rather than at every commit.
+	// Safe under WAL for application-level durability that survives
+	// process crashes; a power loss may roll back the most recent commit
+	// to the last checkpoint. Matrix is event-sourced and re-syncs from
+	// peers, so this trade-off is acceptable.
+	// https://www.sqlite.org/pragma.html#pragma_synchronous
+	dsn += "&_pragma=synchronous%3dNORMAL"
+
 	return dsn
 }

--- a/internal/sqlutil/sqlite_native_test.go
+++ b/internal/sqlutil/sqlite_native_test.go
@@ -1,0 +1,40 @@
+//go:build !cgo
+// +build !cgo
+
+package sqlutil
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestSQLiteNativeDSNExtension verifies that the DSN assembled by
+// sqliteDSNExtension causes the connection to apply the expected PRAGMA
+// values. Run with CGO_ENABLED=0 (or implicitly on builds without a C
+// toolchain) so the modernc.org/sqlite driver is selected.
+func TestSQLiteNativeDSNExtension(t *testing.T) {
+	dsn := sqliteDSNExtension("file:" + filepath.Join(t.TempDir(), "test.db"))
+	db, err := sql.Open(SQLITE_DRIVER_NAME, dsn)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+
+	cases := []struct{ pragma, want string }{
+		{"busy_timeout", "10000"},
+		{"journal_mode", "wal"},
+		{"cache_size", "-32000"},
+		{"synchronous", "1"}, // NORMAL = 1
+	}
+	for _, c := range cases {
+		var got string
+		if err := db.QueryRowContext(context.Background(), "PRAGMA "+c.pragma).Scan(&got); err != nil {
+			t.Fatalf("PRAGMA %s: %v", c.pragma, err)
+		}
+		if got != c.want {
+			t.Errorf("PRAGMA %s = %q, want %q", c.pragma, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The `!cgo` SQLite path (modernc.org/sqlite driver) currently only sets `busy_timeout=10000` on the connection DSN. This PR adds three further pragmas with documented rationale and a regression test:

- `journal_mode=WAL` - readers proceed while a writer is active. Dendrite's storage layer always has concurrent readers and writers, so WAL is the SQLite-recommended setting.
- `cache_size=-32000` - 32 MiB page cache, up from the modernc default of 2 MiB. Federation and sync workloads touch many rooms per request and benefit from a larger working set.
- `synchronous=NORMAL` - fsync only at WAL checkpoints. Safe under WAL for application-level durability that survives process crashes; a power loss may roll back the most recent commit to the last checkpoint, which Matrix recovers from by resyncing peers.

The CGO build path (`sqlite_cgo.go`, `mattn/go-sqlite3`) is untouched.

## Test plan

A new `TestSQLiteNativeDSNExtension` in `internal/sqlutil/sqlite_native_test.go` opens a fresh file-backed database with the assembled DSN and asserts each of the four pragmas round-trips to the expected value (`busy_timeout`, `journal_mode`, `cache_size`, `synchronous`). It carries the `!cgo` build tag so it runs in lock-step with the code under test.

```
CGO_ENABLED=0 go test -run TestSQLiteNativeDSNExtension ./internal/sqlutil/
ok  	github.com/element-hq/dendrite/internal/sqlutil	0.468s
```

## Notes

- The encoded `%3d` form (`=`) of the DSN syntax is kept to match the existing `busy_timeout` line; switching to the parenthesis form (`_pragma=cache_size(-32000)`) would be a separate cosmetic refactor.
- These defaults are tuned for the typical "always-on Dendrite homeserver" deployment. Operators with extreme durability needs can still set `synchronous=FULL` at the OS layer.
