### PR TITLE
all: remove redundant embedded-field references (staticcheck QF1008)

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -194,7 +194,7 @@ func (s *OutputRoomEventConsumer) sendEvents(
 
 	// If txnID is not defined, generate one from the events.
 	if txnID == "" {
-		txnID = fmt.Sprintf("%d_%d", events[0].PDU.OriginServerTS(), len(transaction))
+		txnID = fmt.Sprintf("%d_%d", events[0].OriginServerTS(), len(transaction))
 	}
 
 	// Send the transaction to the appservice.

--- a/clientapi/auth/login_token.go
+++ b/clientapi/auth/login_token.go
@@ -52,8 +52,8 @@ func (t *LoginTypeToken) LoginFromJSON(ctx context.Context, reqBytes []byte) (*L
 		}
 	}
 
-	r.Login.Identifier.Type = "m.id.user"
-	r.Login.Identifier.User = res.Data.UserID
+	r.Identifier.Type = "m.id.user"
+	r.Identifier.User = res.Data.UserID
 
 	cleanup := func(ctx context.Context, authRes *util.JSONResponse) {
 		if authRes == nil {

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -63,9 +63,9 @@ func GetUserDevices(
 
 	for _, dev := range res.Devices {
 		var key fclient.RespUserDeviceKeys
-		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
+		err := json.Unmarshal(dev.KeyJSON, &key)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.DeviceKeys.KeyJSON))
+			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.KeyJSON))
 			continue
 		}
 

--- a/federationapi/routing/profile_test.go
+++ b/federationapi/routing/profile_test.go
@@ -51,7 +51,7 @@ func TestHandleQueryProfile(t *testing.T) {
 		fedMux := mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicFederationPathPrefix).Subrouter().UseEncodedPath()
 		natsInstance := jetstream.NATSInstance{}
 		routers.Federation = fedMux
-		cfg.FederationAPI.Matrix.SigningIdentity.ServerName = testOrigin
+		cfg.FederationAPI.Matrix.ServerName = testOrigin
 		cfg.FederationAPI.Matrix.Metrics.Enabled = false
 		fedClient := fakeFedClient{}
 		serverKeyAPI := &signing.YggdrasilKeys{}

--- a/federationapi/routing/query_test.go
+++ b/federationapi/routing/query_test.go
@@ -49,7 +49,7 @@ func TestHandleQueryDirectory(t *testing.T) {
 		fedMux := mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicFederationPathPrefix).Subrouter().UseEncodedPath()
 		natsInstance := jetstream.NATSInstance{}
 		routers.Federation = fedMux
-		cfg.FederationAPI.Matrix.SigningIdentity.ServerName = testOrigin
+		cfg.FederationAPI.Matrix.ServerName = testOrigin
 		cfg.FederationAPI.Matrix.Metrics.Enabled = false
 		fedClient := fakeFedClient{}
 		serverKeyAPI := &signing.YggdrasilKeys{}

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -48,7 +48,7 @@ func TestHandleSend(t *testing.T) {
 		fedMux := mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicFederationPathPrefix).Subrouter().UseEncodedPath()
 		natsInstance := jetstream.NATSInstance{}
 		routers.Federation = fedMux
-		cfg.FederationAPI.Matrix.SigningIdentity.ServerName = testOrigin
+		cfg.FederationAPI.Matrix.ServerName = testOrigin
 		cfg.FederationAPI.Matrix.Metrics.Enabled = false
 		fedapi := fedAPI.NewInternalAPI(processCtx, cfg, cm, &natsInstance, nil, nil, nil, nil, true)
 		serverKeyAPI := &signing.YggdrasilKeys{}

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -206,7 +206,7 @@ func (r *RoomserverInternalAPI) SetFederationAPI(fsAPI fsAPI.RoomserverFederatio
 		RSAPI: r,
 	}
 
-	if err := r.Inputer.Start(); err != nil {
+	if err := r.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start roomserver input API")
 	}
 }
@@ -235,7 +235,7 @@ func (r *RoomserverInternalAPI) StateQuerier() gomatrixserverlib.StateQuerier {
 func (r *RoomserverInternalAPI) HandleInvite(
 	ctx context.Context, inviteEvent *types.HeaderedEvent,
 ) error {
-	outputEvents, err := r.Inviter.ProcessInviteMembership(ctx, inviteEvent)
+	outputEvents, err := r.ProcessInviteMembership(ctx, inviteEvent)
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -39,7 +39,7 @@ func (q *QueryState) GetAuthEvents(ctx context.Context, event gomatrixserverlib.
 }
 
 func (q *QueryState) GetState(ctx context.Context, roomID spec.RoomID, stateWanted []gomatrixserverlib.StateKeyTuple) ([]gomatrixserverlib.PDU, error) {
-	info, err := q.Database.RoomInfo(ctx, roomID.String())
+	info, err := q.RoomInfo(ctx, roomID.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load RoomInfo: %w", err)
 	}
@@ -55,7 +55,7 @@ func (q *QueryState) GetState(ctx context.Context, roomID spec.RoomID, stateWant
 		for _, stateNID := range stateEntries {
 			stateNIDs = append(stateNIDs, stateNID.EventNID)
 		}
-		stateEvents, err := q.Database.Events(ctx, info.RoomVersion, stateNIDs)
+		stateEvents, err := q.Events(ctx, info.RoomVersion, stateNIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to obtain required events: %w", err)
 		}

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -1163,7 +1163,7 @@ func (v *StateResolution) loadStateEvents(
 			panic(fmt.Errorf("corrupt DB: Missing event numeric ID %d", entry.EventNID))
 		}
 		result = append(result, event.PDU)
-		eventIDMap[event.PDU.EventID()] = entry
+		eventIDMap[event.EventID()] = entry
 		v.events[entry.EventNID] = event.PDU
 	}
 	return result, eventIDMap, nil

--- a/roomserver/types/headered_event.go
+++ b/roomserver/types/headered_event.go
@@ -33,7 +33,7 @@ func (h *HeaderedEvent) CacheCost() int {
 }
 
 func (h *HeaderedEvent) MarshalJSON() ([]byte, error) {
-	return h.PDU.ToHeaderedJSON()
+	return h.ToHeaderedJSON()
 }
 
 func (j *HeaderedEvent) UnmarshalJSON(data []byte) error {

--- a/userapi/internal/user_api.go
+++ b/userapi/internal/user_api.go
@@ -836,20 +836,20 @@ func (a *UserInternalAPI) QueryNotifications(ctx context.Context, req *api.Query
 func (a *UserInternalAPI) PerformPusherSet(ctx context.Context, req *api.PerformPusherSetRequest, res *struct{}) error {
 	util.GetLogger(ctx).WithFields(logrus.Fields{
 		"localpart":    req.Localpart,
-		"pushkey":      req.Pusher.PushKey,
-		"display_name": req.Pusher.AppDisplayName,
+		"pushkey":      req.PushKey,
+		"display_name": req.AppDisplayName,
 	}).Info("PerformPusherCreation")
 	if !req.Append {
-		err := a.DB.RemovePushers(ctx, req.Pusher.AppID, req.Pusher.PushKey)
+		err := a.DB.RemovePushers(ctx, req.AppID, req.PushKey)
 		if err != nil {
 			return err
 		}
 	}
-	if req.Pusher.Kind == "" {
-		return a.DB.RemovePusher(ctx, req.Pusher.AppID, req.Pusher.PushKey, req.Localpart, req.ServerName)
+	if req.Kind == "" {
+		return a.DB.RemovePusher(ctx, req.AppID, req.PushKey, req.Localpart, req.ServerName)
 	}
-	if req.Pusher.PushKeyTS == 0 {
-		req.Pusher.PushKeyTS = int64(time.Now().Unix())
+	if req.PushKeyTS == 0 {
+		req.PushKeyTS = int64(time.Now().Unix())
 	}
 	return a.DB.UpsertPusher(ctx, req.Pusher, req.Localpart, req.ServerName)
 }


### PR DESCRIPTION
## Summary

staticcheck `QF1008` flags the form `outer.Embedded.Field` when `Field` is reachable via promotion from the embedded type. The selector reads more naturally as `outer.Field`, matches how the Go language already resolves the reference, and avoids drawing the reader's attention to a structural detail (which type happens to embed which) that is not relevant at the call site.

This PR rewrites 13 such call sites across:

- `appservice/consumers/roomserver.go` — `events[0].PDU.OriginServerTS()` → `events[0].OriginServerTS()`
- `clientapi/auth/login_token.go` — `r.Login.Identifier.X` → `r.Identifier.X` (×2)
- `federationapi/routing/devices.go` — `dev.DeviceKeys.KeyJSON` → `dev.KeyJSON` (×2)
- `federationapi/routing/{profile,query,send}_test.go` — `cfg.FederationAPI.Matrix.SigningIdentity.ServerName` → `cfg.FederationAPI.Matrix.ServerName` (×3)
- `roomserver/internal/api.go` — `r.Inputer.Start()` → `r.Start()`, `r.Inviter.ProcessInviteMembership` → `r.ProcessInviteMembership`
- `roomserver/internal/perform/perform_invite.go` — `q.Database.X` → `q.X` (×2)
- `roomserver/state/state.go` — `event.PDU.EventID()` → `event.EventID()`
- `roomserver/types/headered_event.go` — `h.PDU.ToHeaderedJSON()` → `h.ToHeaderedJSON()`
- `userapi/internal/user_api.go` — `req.Pusher.X` → `req.X` (×6 field reads/writes)

No behavior change: the referenced field is the same in each case, only the explicit traversal through the embedded type is dropped.

`req.Pusher` is intentionally **left in place** at the one site in `PerformPusherSet` where it's passed by value to `UpsertPusher` — that needs the embedded struct itself, not a field on it.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./roomserver/state/ ./roomserver/types/` passes (other affected packages need a live Postgres which I don't have locally; CI here is the better signal)
- [ ] CI lint/test on this PR

Happy to split this up by package or drop individual hunks if any of them is sensitive.