### PR TITLE
all: deduplicate same-package imports (staticcheck ST1019)

### DIFF
--- a/clientapi/routing/admin.go
+++ b/clientapi/routing/admin.go
@@ -25,7 +25,6 @@ import (
 	roomserverAPI "github.com/element-hq/dendrite/roomserver/api"
 	"github.com/element-hq/dendrite/setup/config"
 	"github.com/element-hq/dendrite/setup/jetstream"
-	"github.com/element-hq/dendrite/userapi/api"
 	userapi "github.com/element-hq/dendrite/userapi/api"
 )
 
@@ -328,7 +327,7 @@ func AdminPurgeRoom(req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI) 
 	}
 }
 
-func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
+func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	if req.Body == nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -348,8 +347,8 @@ func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.De
 			JSON: spec.InvalidParam(err.Error()),
 		}
 	}
-	accAvailableResp := &api.QueryAccountAvailabilityResponse{}
-	if err = userAPI.QueryAccountAvailability(req.Context(), &api.QueryAccountAvailabilityRequest{
+	accAvailableResp := &userapi.QueryAccountAvailabilityResponse{}
+	if err = userAPI.QueryAccountAvailability(req.Context(), &userapi.QueryAccountAvailabilityRequest{
 		Localpart:  localpart,
 		ServerName: serverName,
 	}, accAvailableResp); err != nil {
@@ -385,13 +384,13 @@ func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.De
 		return *internal.PasswordResponse(err)
 	}
 
-	updateReq := &api.PerformPasswordUpdateRequest{
+	updateReq := &userapi.PerformPasswordUpdateRequest{
 		Localpart:     localpart,
 		ServerName:    serverName,
 		Password:      request.Password,
 		LogoutDevices: request.LogoutDevices,
 	}
-	updateRes := &api.PerformPasswordUpdateResponse{}
+	updateRes := &userapi.PerformPasswordUpdateResponse{}
 	if err := userAPI.PerformPasswordUpdate(req.Context(), updateReq, updateRes); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -408,7 +407,7 @@ func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.De
 	}
 }
 
-func AdminReindex(req *http.Request, cfg *config.ClientAPI, device *api.Device, natsClient *nats.Conn) util.JSONResponse {
+func AdminReindex(req *http.Request, cfg *config.ClientAPI, device *userapi.Device, natsClient *nats.Conn) util.JSONResponse {
 	_, err := natsClient.RequestMsg(nats.NewMsg(cfg.Matrix.JetStream.Prefixed(jetstream.InputFulltextReindex)), time.Second*10)
 	if err != nil {
 		logrus.WithError(err).Error("failed to publish nats message")
@@ -441,7 +440,7 @@ func AdminMarkAsStale(req *http.Request, cfg *config.ClientAPI, keyAPI userapi.C
 		}
 	}
 
-	err = keyAPI.PerformMarkAsStaleIfNeeded(req.Context(), &api.PerformMarkAsStaleRequest{
+	err = keyAPI.PerformMarkAsStaleIfNeeded(req.Context(), &userapi.PerformMarkAsStaleRequest{
 		UserID: userID,
 		Domain: domain,
 	}, &struct{}{})
@@ -457,7 +456,7 @@ func AdminMarkAsStale(req *http.Request, cfg *config.ClientAPI, keyAPI userapi.C
 	}
 }
 
-func AdminDownloadState(req *http.Request, device *api.Device, rsAPI roomserverAPI.ClientRoomserverAPI) util.JSONResponse {
+func AdminDownloadState(req *http.Request, device *userapi.Device, rsAPI roomserverAPI.ClientRoomserverAPI) util.JSONResponse {
 	vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 	if err != nil {
 		return util.ErrorResponse(err)

--- a/cmd/dendrite-demo-yggdrasil/yggconn/node.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/node.go
@@ -20,16 +20,14 @@ import (
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/config"
 	"github.com/yggdrasil-network/yggdrasil-go/src/core"
-	yggdrasilcore "github.com/yggdrasil-network/yggdrasil-go/src/core"
 	"github.com/yggdrasil-network/yggdrasil-go/src/multicast"
-	yggdrasilmulticast "github.com/yggdrasil-network/yggdrasil-go/src/multicast"
 
 	gologme "github.com/gologme/log"
 )
 
 type Node struct {
-	core      *yggdrasilcore.Core
-	multicast *yggdrasilmulticast.Multicast
+	core      *core.Core
+	multicast *multicast.Multicast
 	log       *gologme.Logger
 	*yggquic.YggdrasilTransport
 }
@@ -56,13 +54,13 @@ func Setup(sk ed25519.PrivateKey, instanceName, storageDirectory, peerURI, liste
 
 	{
 		var err error
-		options := []yggdrasilcore.SetupOption{}
+		options := []core.SetupOption{}
 		if listenURI != "" {
-			options = append(options, yggdrasilcore.ListenAddress(listenURI))
+			options = append(options, core.ListenAddress(listenURI))
 		}
 		if peerURI != "" {
 			for _, uri := range strings.Split(peerURI, ",") {
-				options = append(options, yggdrasilcore.Peer{
+				options = append(options, core.Peer{
 					URI: uri,
 				})
 			}

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/nats-io/nats.go"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/element-hq/dendrite/federationapi/queue"
@@ -127,9 +126,9 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msgs []*nats.Ms
 	case api.OutputTypePurgeRoom:
 		log.WithField("room_id", output.PurgeRoom.RoomID).Warn("Purging room from federation API")
 		if err := s.db.PurgeRoom(ctx, output.PurgeRoom.RoomID); err != nil {
-			logrus.WithField("room_id", output.PurgeRoom.RoomID).WithError(err).Error("Failed to purge room from federation API")
+			log.WithField("room_id", output.PurgeRoom.RoomID).WithError(err).Error("Failed to purge room from federation API")
 		} else {
-			logrus.WithField("room_id", output.PurgeRoom.RoomID).Warn("Room purged from federation API")
+			log.WithField("room_id", output.PurgeRoom.RoomID).Warn("Room purged from federation API")
 		}
 
 	default:

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -18,7 +18,6 @@ import (
 	"github.com/element-hq/dendrite/federationapi/producers"
 	"github.com/element-hq/dendrite/internal"
 	"github.com/element-hq/dendrite/internal/httputil"
-	"github.com/element-hq/dendrite/roomserver/api"
 	roomserverAPI "github.com/element-hq/dendrite/roomserver/api"
 	"github.com/element-hq/dendrite/setup/config"
 	userapi "github.com/element-hq/dendrite/userapi/api"
@@ -600,15 +599,15 @@ func Setup(
 
 func ErrorIfLocalServerNotInRoom(
 	ctx context.Context,
-	rsAPI api.FederationRoomserverAPI,
+	rsAPI roomserverAPI.FederationRoomserverAPI,
 	roomID string,
 ) *util.JSONResponse {
 	// Check if we think we're in this room. If we aren't then
 	// we won't waste CPU cycles serving this request.
-	joinedReq := &api.QueryServerJoinedToRoomRequest{
+	joinedReq := &roomserverAPI.QueryServerJoinedToRoomRequest{
 		RoomID: roomID,
 	}
-	joinedRes := &api.QueryServerJoinedToRoomResponse{}
+	joinedRes := &roomserverAPI.QueryServerJoinedToRoomResponse{}
 	if err := rsAPI.QueryServerJoinedToRoom(ctx, joinedReq, joinedRes); err != nil {
 		res := util.ErrorResponse(err)
 		return &res

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -25,7 +25,6 @@ import (
 
 	fsAPI "github.com/element-hq/dendrite/federationapi/api"
 	"github.com/element-hq/dendrite/internal/eventutil"
-	"github.com/element-hq/dendrite/roomserver/api"
 	rsAPI "github.com/element-hq/dendrite/roomserver/api"
 	"github.com/element-hq/dendrite/roomserver/internal/helpers"
 	"github.com/element-hq/dendrite/roomserver/internal/input"
@@ -339,7 +338,7 @@ func (r *Joiner) performJoinRoomByID(
 		// a member of the room. This is best-effort (as in we won't
 		// fail if we can't find the existing membership) because there
 		// is really no harm in just sending another membership event.
-		membershipRes := &api.QueryMembershipForUserResponse{}
+		membershipRes := &rsAPI.QueryMembershipForUserResponse{}
 		_ = r.Queryer.QueryMembershipForSenderID(ctx, *roomID, senderID, membershipRes)
 
 		// If we haven't already joined the room then send an event

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -22,7 +22,6 @@ import (
 
 	fsAPI "github.com/element-hq/dendrite/federationapi/api"
 	"github.com/element-hq/dendrite/roomserver/api"
-	rsAPI "github.com/element-hq/dendrite/roomserver/api"
 	"github.com/element-hq/dendrite/roomserver/internal/helpers"
 	"github.com/element-hq/dendrite/roomserver/internal/input"
 	"github.com/element-hq/dendrite/roomserver/storage"
@@ -34,7 +33,7 @@ type Leaver struct {
 	Cfg     *config.RoomServer
 	DB      storage.Database
 	FSAPI   fsAPI.RoomserverFederationAPI
-	RSAPI   rsAPI.RoomserverInternalAPI
+	RSAPI   api.RoomserverInternalAPI
 	UserAPI userapi.RoomserverUserAPI
 	Inputer *input.Inputer
 }
@@ -185,7 +184,7 @@ func (r *Leaver) performLeaveRoomByID(
 		return nil, err
 	}
 
-	var buildRes rsAPI.QueryLatestEventsAndStateResponse
+	var buildRes api.QueryLatestEventsAndStateResponse
 	identity, err := r.RSAPI.SigningIdentityFor(ctx, *validRoomID, req.Leaver)
 	if err != nil {
 		return nil, fmt.Errorf("SigningIdentityFor: %w", err)

--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -16,7 +16,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 
 	"github.com/element-hq/dendrite/internal/eventutil"
@@ -144,7 +143,7 @@ func (s *OutputClientDataConsumer) Start() error {
 	)
 }
 
-// onMessage is called when the sync server receives a new event from the client API server output log.
+// onMessage is called when the sync server receives a new event from the client API server output logrus.
 // It is not safe for this function to be called from multiple goroutines, or else the
 // sync stream position may race and be incorrectly calculated.
 func (s *OutputClientDataConsumer) onMessage(ctx context.Context, msgs []*nats.Msg) bool {
@@ -154,12 +153,12 @@ func (s *OutputClientDataConsumer) onMessage(ctx context.Context, msgs []*nats.M
 	var output eventutil.AccountData
 	if err := json.Unmarshal(msg.Data, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
-		log.WithError(err).Errorf("client API server output log: message parse failure")
+		logrus.WithError(err).Errorf("client API server output log: message parse failure")
 		sentry.CaptureException(err)
 		return true
 	}
 
-	log.WithFields(log.Fields{
+	logrus.WithFields(logrus.Fields{
 		"type":    output.Type,
 		"room_id": output.RoomID,
 	}).Debug("Received data from client API server")
@@ -169,17 +168,17 @@ func (s *OutputClientDataConsumer) onMessage(ctx context.Context, msgs []*nats.M
 	)
 	if err != nil {
 		sentry.CaptureException(err)
-		log.WithFields(log.Fields{
+		logrus.WithFields(logrus.Fields{
 			"type":       output.Type,
 			"room_id":    output.RoomID,
-			log.ErrorKey: err,
+			logrus.ErrorKey: err,
 		}).Errorf("could not save account data")
 		return false
 	}
 
 	if output.IgnoredUsers != nil {
 		if err := s.db.UpdateIgnoresForUser(ctx, userID, output.IgnoredUsers); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
+			logrus.WithError(err).WithFields(logrus.Fields{
 				"user_id": userID,
 			}).Errorf("Failed to update ignored users")
 			sentry.CaptureException(err)

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -30,7 +30,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/nats-io/nats.go"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
@@ -135,7 +134,7 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msgs []*nats.Ms
 	case api.OutputTypePurgeRoom:
 		err = s.onPurgeRoom(s.ctx, *output.PurgeRoom)
 		if err != nil {
-			logrus.WithField("room_id", output.PurgeRoom.RoomID).WithError(err).Error("Failed to purge room from sync API")
+			log.WithField("room_id", output.PurgeRoom.RoomID).WithError(err).Error("Failed to purge room from sync API")
 			return true // non-fatal, as otherwise we end up in a loop of trying to purge the room
 		}
 	default:
@@ -518,13 +517,13 @@ func (s *OutputRoomEventConsumer) onRetirePeek(
 func (s *OutputRoomEventConsumer) onPurgeRoom(
 	ctx context.Context, req api.OutputPurgeRoom,
 ) error {
-	logrus.WithField("room_id", req.RoomID).Warn("Purging room from sync API")
+	log.WithField("room_id", req.RoomID).Warn("Purging room from sync API")
 
 	if err := s.db.PurgeRoom(ctx, req.RoomID); err != nil {
-		logrus.WithField("room_id", req.RoomID).WithError(err).Error("Failed to purge room from sync API")
+		log.WithField("room_id", req.RoomID).WithError(err).Error("Failed to purge room from sync API")
 		return err
 	} else {
-		logrus.WithField("room_id", req.RoomID).Warn("Room purged from sync API")
+		log.WithField("room_id", req.RoomID).Warn("Room purged from sync API")
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary

A handful of files imported the same package twice, once plain and once aliased. staticcheck `ST1019` flags this because the two names refer to the same package and add no information; one of them is redundant.

For each file the dominant name in the body wins and the other import is removed, with the affected references renamed to match.

| File | Duplicate | Kept |
|---|---|---|
| `clientapi/routing/admin.go` | `api` + `userapi` for `userapi/api` | `userapi` (matches repo-wide convention, ~73 files vs ~10) |
| `cmd/dendrite-demo-yggdrasil/yggconn/node.go` | `yggdrasilcore` + plain `core`; `yggdrasilmulticast` + plain `multicast` | plain names |
| `federationapi/consumers/roomserver.go` | `logrus` + `log` | `log` (12 uses vs 2) |
| `federationapi/routing/routing.go` | `api` + `roomserverAPI` for `roomserver/api` | `roomserverAPI` (17 vs 3) |
| `roomserver/internal/perform/perform_join.go` | `api` + `rsAPI` for `roomserver/api` | `rsAPI` (23 vs 1) |
| `roomserver/internal/perform/perform_leave.go` | `api` + `rsAPI` for `roomserver/api` | `api` (18 vs 2) |
| `syncapi/consumers/clientapi.go` | `logrus` + `log` | `logrus` (7 vs 6, matches repo majority) |
| `syncapi/consumers/roomserver.go` | `logrus` + `log` | `log` (32 vs 4) |

The kept name was chosen per-file to minimize the number of touched call sites; happy to flip any of them if there's a project-wide convention I missed.

No behavior change; only import aliases and the corresponding qualifier on call sites move.

## Test plan

- [x] `go build ./...` clean
- [ ] CI lint/test on this PR