### PR TITLE
all: drop redundant blank lines flagged by the whitespace linter

### DIFF
--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -32,7 +32,6 @@ func NewInternalAPI(
 	userAPI userapi.AppserviceUserAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 ) appserviceAPI.AppServiceInternalAPI {
-
 	// Create appserivce query API with an HTTP client that will be used for all
 	// outbound and inbound requests (inbound only for the internal API)
 	appserviceQueryAPI := &query.AppServiceQueryAPI{

--- a/appservice/query/query.go
+++ b/appservice/query/query.go
@@ -296,7 +296,6 @@ func (a *AppServiceQueryAPI) Protocols(
 
 	// get a single protocol response
 	if req.Protocol != "" {
-
 		a.CacheMu.Lock()
 		defer a.CacheMu.Unlock()
 		if proto, ok := a.ProtocolCache[req.Protocol]; ok {

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -314,5 +314,4 @@ func handleInviteResult(ctx context.Context, inviteEvent gomatrixserverlib.PDU, 
 		}
 	}
 	return inviteEvent, nil
-
 }

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -263,7 +263,6 @@ func SendJoin(
 			Code: http.StatusInternalServerError,
 			JSON: spec.InternalServerError{},
 		}
-
 	}
 
 	// Fetch the state and auth chain. We do this before we send the events

--- a/federationapi/routing/publicrooms.go
+++ b/federationapi/routing/publicrooms.go
@@ -53,7 +53,6 @@ func GetPostPublicRooms(req *http.Request, rsAPI roomserverAPI.FederationRoomser
 func publicRooms(
 	ctx context.Context, request PublicRoomReq, rsAPI roomserverAPI.FederationRoomserverAPI,
 ) (*fclient.RespPublicRooms, error) {
-
 	var response fclient.RespPublicRooms
 	var limit int16
 	var offset int64

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1521,7 +1521,6 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 			continue
 		}
 		eventStateKeys = append(eventStateKeys, tuple.StateKey)
-
 	}
 
 	eventStateKeyNIDMap, err := d.eventStateKeyNIDs(ctx, nil, eventStateKeys)


### PR DESCRIPTION
## Summary

Six instances of stray blank lines either at the start of a block (right after an opening brace) or at the end of one (right before a closing brace), across appservice, federationapi and roomserver. The whitespace linter flags both shapes; gofmt does not touch them, so they had to be removed by hand.

| File | Shape |
|---|---|
| `appservice/appservice.go:34` | leading newline after `{` |
| `appservice/query/query.go:298` | leading newline after `{` |
| `federationapi/routing/invite.go:318` | trailing newline before `}` |
| `federationapi/routing/join.go:267` | trailing newline before `}` |
| `federationapi/routing/publicrooms.go:55` | leading newline after `{` |
| `roomserver/storage/shared/storage.go:1525` | trailing newline before `}` |

No behavior change.

## Test plan

- [x] `go build ./...` clean
- [ ] CI lint/test on this PR