### PR TITLE
all: replace strings.Replace(_, -1) with strings.ReplaceAll

### DIFF
--- a/internal/pushrules/util.go
+++ b/internal/pushrules/util.go
@@ -61,8 +61,8 @@ func globToRegexp(pattern string) (*regexp.Regexp, error) {
 	// characters, which makes this a straight-forward
 	// replace-after-quote.
 	pattern = globNonMetaRegexp.ReplaceAllStringFunc(pattern, regexp.QuoteMeta)
-	pattern = strings.Replace(pattern, "*", ".*", -1)
-	pattern = strings.Replace(pattern, "?", ".", -1)
+	pattern = strings.ReplaceAll(pattern, "*", ".*")
+	pattern = strings.ReplaceAll(pattern, "?", ".")
 	return regexp.Compile("^(" + pattern + ")$")
 }
 

--- a/syncapi/storage/postgres/filtering.go
+++ b/syncapi/storage/postgres/filtering.go
@@ -25,7 +25,7 @@ func filterConvertTypeWildcardToSQL(values *[]string) []string {
 	v := *values
 	ret := make([]string, len(v))
 	for i := range v {
-		ret[i] = strings.Replace(v[i], "*", "%", -1)
+		ret[i] = strings.ReplaceAll(v[i], "*", "%")
 	}
 	return ret
 }


### PR DESCRIPTION
## Summary

staticcheck `QF1004` prefers `strings.ReplaceAll` over `strings.Replace` with a `-1` count: the intent of replace-everywhere is clearer in the name and matches the form added to the standard library in Go 1.12.

Three call sites across two files:

- `internal/pushrules/util.go` — glob-to-regex translation (`*` → `.*`, `?` → `.`)
- `syncapi/storage/postgres/filtering.go` — glob-to-LIKE translation (`*` → `%`)

No behavior change.

## Test plan

- [x] `go build ./...` clean
- [ ] CI lint/test on this PR